### PR TITLE
Add direct editor button

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -96,3 +96,19 @@ function sanitizeHtml(html) {
   
   return html;
 }
+
+/**
+ * Insère un bouton d'accès direct à l'éditeur HTML.
+ * Le bouton est ajouté en haut à gauche de la feuille et
+ * exécute la fonction editActiveCellDialog lors d'un clic.
+ */
+function insertEditorButton() {
+  var sheet = SpreadsheetApp.getActiveSheet();
+  var imageUrl = 'https://www.gstatic.com/images/icons/material/system/1x/edit_black_24dp.png';
+  var blob = UrlFetchApp.fetch(imageUrl).getBlob();
+  var button = sheet.insertImage(blob, 1, 1);
+  if (button.assignScript) {
+    button.assignScript('editActiveCellDialog');
+  }
+  button.setAltTextDescription('Éditer la cellule active');
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Éditeur HTML pour Google Sheets
 
-Ce script ajoute un éditeur WYSIWYG pour modifier le contenu HTML d'une cellule.
-L'éditeur s'ouvre toujours dans une boîte de dialogue modale pour offrir plus
-d'espace d'édition.
+Ce script ajoute un éditeur WYSIWYG pour modifier le contenu HTML d'une cellule. L'éditeur s'ouvre toujours dans une boîte de dialogue modale pour offrir plus d'espace d'édition.
+
+## Bouton d'accès direct
+
+Vous pouvez insérer un dessin ou une image dans la feuille puis lui attribuer la fonction `editActiveCellDialog`. Ainsi, un simple clic sur cette image ouvrira l'éditeur pour la cellule active.
+
+Pour automatiser l'ajout du bouton, exécutez la fonction `insertEditorButton` depuis l'éditeur Apps Script. Une petite icône sera placée en haut à gauche de la feuille et lancera `editActiveCellDialog` lorsqu'on clique dessus.


### PR DESCRIPTION
## Summary
- add `insertEditorButton` to automatically insert an image that launches the HTML editor
- document how to use the new function and how to assign a script to an image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684860323ff08320b94a9f7836661add