### PR TITLE
Fix default header color in editor

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -302,7 +302,8 @@
     }
 
     #visualEditor table th {
-      background: rgba(79, 70, 229, 0.05);
+      background-color: #6ea6cf;
+      color: white;
       font-weight: 600;
     }
 


### PR DESCRIPTION
## Summary
- ensure table header cells show blue background color by default

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68488e5a0c148320a8cffbe0b3799b72