### PR TITLE
Fix editor behavior with pre-filled cells

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -87,8 +87,9 @@ function openEditor(cell) {
   
   // Utiliser getValue() avec une vérification rapide
   const value = cell.getValue();
+  const cleanValue = sanitizeHtml(value);
   const cellData = {
-    content: value || '',
+    content: cleanValue || '',
     row: cell.getRow(),
     col: cell.getColumn(),
   };

--- a/editor.html
+++ b/editor.html
@@ -1071,7 +1071,8 @@
   
   <script>
     let currentTab = 'visual';
-    let cellData = <?!= JSON.stringify(cellData) ?>;
+    // Échapper les chevrons pour éviter toute rupture de la balise <script>
+    let cellData = <?!= JSON.stringify(cellData).replace(/</g, '\x3c') ?>;
     let undoStack = [];
     let redoStack = [];
     let maxUndoSteps = 50;


### PR DESCRIPTION
## Summary
- sanitize loaded cell content before injecting into the editor
- escape `<` chars when embedding cell data inside `<script>` tag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68488f6f3e2c8320ac037d193d5ead44