### PR TITLE
Fix toolbar sync and code tab

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -1086,9 +1086,21 @@
       document.addEventListener('keydown', handleKeyPress);
 
       // Ajouter un écouteur pour détecter quand on est dans un tableau
-      document.getElementById('visualEditor').addEventListener('click', handleSelectionChange);
-      document.getElementById('visualEditor').addEventListener('keyup', handleSelectionChange);
+      const visual = document.getElementById('visualEditor');
+      const code = document.getElementById('htmlEditor');
+
+      visual.addEventListener('click', handleSelectionChange);
+      visual.addEventListener('keyup', handleSelectionChange);
+      visual.addEventListener('mouseup', handleSelectionChange);
+      visual.addEventListener('focus', handleSelectionChange);
       document.addEventListener('selectionchange', handleSelectionChange);
+
+      // Garder les deux vues synchronisées
+      visual.addEventListener('input', () => {
+        syncContent();
+        handleSelectionChange();
+      });
+      code.addEventListener('input', syncContent);
 
       const textPicker = document.getElementById('textColorPicker');
       const bgPicker = document.getElementById('bgColorPicker');
@@ -1306,6 +1318,7 @@
       }
       
       currentTab = tab;
+      handleSelectionChange();
     }
     
     let syncTimer;


### PR DESCRIPTION
## Summary
- add input and focus handlers to sync editor with toolbar
- refresh toolbar state after switching tabs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684890bdeb4c8320897e1b62acc939eb